### PR TITLE
remove hardcoded O01 ACK message type

### DIFF
--- a/lib/mllp/ack.ex
+++ b/lib/mllp/ack.ex
@@ -38,7 +38,6 @@ defmodule MLLP.Ack do
     msa = ["MSA", "AR", message_control_id, "Message was not parsable as HL7"]
 
     HL7.Message.new([msh, msa]) |> to_string()
-
   end
 
   defp make_ack_hl7(message, code, text_message) do
@@ -57,7 +56,7 @@ defmodule MLLP.Ack do
       |> List.replace_at(6, sending_facility)
       |> List.replace_at(3, receiving_app)
       |> List.replace_at(5, sending_app)
-      |> List.replace_at(9, "ACK^O01")
+      |> List.replace_at(9, "ACK")
 
     msa = ["MSA", code, message_control_id, text_message]
 
@@ -65,7 +64,6 @@ defmodule MLLP.Ack do
   end
 
   def verify_ack_against_message(%HL7.Message{} = message, %HL7.Message{} = ack) do
-
     message_hl7 = message |> HL7.Message.new()
     ack_hl7 = ack |> HL7.Message.new()
 

--- a/lib/mllp/ack.ex
+++ b/lib/mllp/ack.ex
@@ -29,7 +29,7 @@ defmodule MLLP.Ack do
       "????",
       DateTime.utc_now() |> to_string(),
       "",
-      "ACK^O01",
+      "ACK",
       message_control_id,
       "P",
       "2.5"

--- a/test/ack_test.exs
+++ b/test/ack_test.exs
@@ -22,7 +22,7 @@ defmodule AckTest do
     hl7_ack = get_ack_for_wikipedia_example(:application_accept)
 
     assert "ACK" == hl7_ack.header.message_type
-    assert "O01" == hl7_ack.header.trigger_event
+    assert "ACK" == hl7_ack.header.trigger_event
   end
 
   test "The ACK for an HL7 message has an MSA with the original MessageControlID" do


### PR DESCRIPTION
The ACK message type was previously hardcoded as ACK^O01, which is not valid for all message types. This changes it to a generic ACK. In theory, we could pull out the correct message type from the parsed message but I did not do that.